### PR TITLE
Add support to use JsonElement values

### DIFF
--- a/src/main/java/org/jglue/fluentjson/JsonArrayBuilder.java
+++ b/src/main/java/org/jglue/fluentjson/JsonArrayBuilder.java
@@ -15,9 +15,10 @@
  */
 package org.jglue.fluentjson;
 
+import com.google.gson.JsonElement;
+
 import java.time.temporal.Temporal;
 import java.util.Date;
-import java.util.List;
 
 
 
@@ -103,7 +104,15 @@ public interface JsonArrayBuilder<P, R> extends JsonBuilder {
 	 * @return the current builder.
 	 */
 	public JsonArrayBuilder<P, R> add(Temporal value);
-	
+
+	/**
+	 * Add a single JSON element to this array.
+	 *
+	 * @param value the value to add.
+	 * @return the current builder.
+	 */
+	public JsonArrayBuilder<P, R> add(JsonElement value);
+
 	/**
 	 * Add an array of elements.
 	 * 

--- a/src/main/java/org/jglue/fluentjson/JsonBuilderFactory.java
+++ b/src/main/java/org/jglue/fluentjson/JsonBuilderFactory.java
@@ -15,22 +15,17 @@
  */
 package org.jglue.fluentjson;
 
+import com.google.gson.*;
+import com.google.gson.internal.Streams;
+import com.google.gson.stream.JsonWriter;
+
 import java.io.IOException;
 import java.io.Writer;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-import java.time.ZoneId;
 import java.time.temporal.Temporal;
 import java.util.Date;
-import java.util.Map;
 import java.util.TimeZone;
-
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonNull;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
-import com.google.gson.stream.JsonWriter;
 
 /**
  * Factory for builders.
@@ -193,6 +188,13 @@ public class JsonBuilderFactory {
 		}
 
 		@Override
+		public JsonObjectBuilder add(String key, JsonElement value) {
+			JsonObject obj = (JsonObject) context;
+			obj.add(key, value);
+			return this;
+		}
+
+		@Override
 		public String toString() {
 			return root.toString();
 		}
@@ -287,7 +289,11 @@ public class JsonBuilderFactory {
 
 		@Override
 		public void write(JsonWriter out) throws IOException {
-			write(out, root);
+			if (root == null) {
+				out.nullValue();
+			} else {
+				Streams.write(root, out);
+			}
 		}
 
 		@Override
@@ -326,42 +332,6 @@ public class JsonBuilderFactory {
 				add(transform.map(object));
 			}
 			return this;
-		}
-
-		/**
-		 * Serialization code copied from GSON
-		 */
-		private void write(JsonWriter out, JsonElement value) throws IOException {
-			if (value == null || value.isJsonNull()) {
-				out.nullValue();
-			} else if (value.isJsonPrimitive()) {
-				JsonPrimitive primitive = value.getAsJsonPrimitive();
-				if (primitive.isNumber()) {
-					out.value(primitive.getAsNumber());
-				} else if (primitive.isBoolean()) {
-					out.value(primitive.getAsBoolean());
-				} else {
-					out.value(primitive.getAsString());
-				}
-
-			} else if (value.isJsonArray()) {
-				out.beginArray();
-				for (JsonElement e : value.getAsJsonArray()) {
-					write(out, e);
-				}
-				out.endArray();
-
-			} else if (value.isJsonObject()) {
-				out.beginObject();
-				for (Map.Entry<String, JsonElement> e : value.getAsJsonObject().entrySet()) {
-					out.name(e.getKey());
-					write(out, e.getValue());
-				}
-				out.endObject();
-
-			} else {
-				throw new IllegalArgumentException("Couldn't write " + value.getClass());
-			}
 		}
 
 		@Override
@@ -427,6 +397,13 @@ public class JsonBuilderFactory {
 			} else {
 				array.add(new JsonPrimitive(value.toString()));
 			}
+			return this;
+		}
+
+		@Override
+		public JsonArrayBuilder<P, R> add(JsonElement value) {
+			JsonArray array = ((JsonArray) context);
+			array.add(value);
 			return this;
 		}
 	}

--- a/src/main/java/org/jglue/fluentjson/JsonObjectBuilder.java
+++ b/src/main/java/org/jglue/fluentjson/JsonObjectBuilder.java
@@ -15,6 +15,8 @@
  */
 package org.jglue.fluentjson;
 
+import com.google.gson.JsonElement;
+
 import java.time.temporal.Temporal;
 import java.util.Date;
 
@@ -80,7 +82,16 @@ public interface JsonObjectBuilder<P, R> extends JsonBuilder {
      * @return The current builder.
      */
     public JsonObjectBuilder<P, R> add(String key, JsonBuilder builder);
-    
+
+    /**
+     * Add a single JSON element assigned to a key.
+     *
+     * @param key The key for the new element.
+     * @param builder The builder for the element.
+     * @return The current builder.
+     */
+    JsonObjectBuilder add(String key, JsonElement value);
+
     /**
      * Add a single element assigned to a key.
      * 


### PR DESCRIPTION
Hey

I like this fluent wrapper. I missed the support to use JsonElement values, so it's possible things like this:

``` java
        Map<String, String> values = new HashMap<>();
        values.put("key", "value");

        JsonElement mapAsElement = new Gson().toJsonTree(values);

        JsonBuilderFactory.buildObject().add("map", mapAsElement);
```

Might be useful create a static Gson instance inside `JsonBuilderFactory` and include the method `addObject` as shortcut to this use case. 

Thank you
